### PR TITLE
Update Matthew bio: 15 → 20 years expertise

### DIFF
--- a/src/content/team/matthew-strickland.md
+++ b/src/content/team/matthew-strickland.md
@@ -2,7 +2,7 @@
 name: "Matthew Strickland"
 role: "Founder & CEO"
 image: "/img/us/matthew.jpg"
-bio: "Matthew Strickland is an experienced technology leader with a proven track record of delivering exceptional digital experiences. As Founder of Idle Fusion, he brings over 15 years of expertise in mobile app development, web technologies, and digital strategy."
+bio: "Matthew Strickland is an experienced technology leader with a proven track record of delivering exceptional digital experiences. As Founder of Idle Fusion, he brings over 20 years of expertise in mobile app development, web technologies, and digital strategy."
 socialLinks:
   linkedin: "https://linkedin.com/in/mps"
   github: "https://github.com/idlefusion"


### PR DESCRIPTION
Update Matthew Strickland's bio on the team page to reflect 20 years of expertise instead of 15.