### PR TITLE
Add Cloudflare Workers deployment config and DNS automation

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -1,0 +1,35 @@
+name: Deploy to Cloudflare Workers
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+concurrency:
+  group: "cloudflare-deploy"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build with Astro
+        run: npm run build
+
+      - name: Deploy to Cloudflare Workers
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,54 @@
+# Cloudflare Workers Migration Checklist
+
+## Before Merge
+
+### 1. Create Cloudflare API Token
+- Go to **Cloudflare Dashboard > My Profile > API Tokens > Create Token**
+- Permissions needed:
+  - `Zone : DNS : Edit`
+  - `Account : Cloudflare Workers Scripts : Edit`
+- Scope it to the `idlefusion.com` zone and your account
+
+### 2. Gather IDs
+- **Account ID**: Dashboard > Workers & Pages > right sidebar
+- **Zone ID**: Dashboard > idlefusion.com > Overview > right sidebar
+
+### 3. Add GitHub Repository Secrets
+Go to **Settings > Secrets and variables > Actions** and add:
+- `CLOUDFLARE_API_TOKEN` — the token from step 1
+- `CLOUDFLARE_ACCOUNT_ID` — the account ID from step 2
+
+### 4. Run DNS Setup
+Point the domain at Cloudflare Workers:
+```bash
+export CF_API_TOKEN="<your-token>"
+export CF_ZONE_ID="<your-zone-id>"
+npm run dns:setup
+```
+This creates CNAME records for `idlefusion.com` and `www.idlefusion.com` pointing to the Workers route.
+
+### 5. Test a Manual Deploy
+From this branch, run:
+```bash
+npm run deploy
+```
+Confirm that `https://idlefusion.com` loads correctly from Cloudflare Workers.
+
+## After Merge
+
+### 6. Verify CI/CD
+- The push to `master` triggers `.github/workflows/deploy-cloudflare.yml`
+- Check the **Actions** tab to confirm the deploy succeeds
+
+### 7. Disable GitHub Pages
+- Go to **Settings > Pages > Source > None**
+- This prevents the old `deploy.yml` workflow from deploying to a now-unused target
+
+### 8. Delete the Old Workflow
+Remove `.github/workflows/deploy.yml` since GitHub Pages is no longer used.
+
+## Timing Notes
+- Steps 4 and 5 should happen **before** merge so there is no downtime gap
+- DNS propagation through Cloudflare's proxy is near-instant since the nameservers are already on Cloudflare
+- The cutover: the old site serves until the CNAME records update, then Workers takes over
+- Expected downtime is seconds, not minutes

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "start": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
+    "deploy": "astro build && wrangler deploy",
+    "dns:setup": "./scripts/setup-dns.sh",
     "astro": "astro"
   },
   "dependencies": {
@@ -15,6 +17,7 @@
     "tailwindcss": "^3.4.0"
   },
   "devDependencies": {
-    "puppeteer": "^24.35.0"
+    "puppeteer": "^24.35.0",
+    "wrangler": "^4.0.0"
   }
 }

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,1 +1,0 @@
-idlefusion.com

--- a/scripts/setup-dns.sh
+++ b/scripts/setup-dns.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+#
+# Cloudflare DNS setup for idlefusion.com
+#
+# Automates DNS record creation/updates for Cloudflare Workers deployment.
+# Requires: CF_API_TOKEN and CF_ZONE_ID environment variables.
+#
+# Usage:
+#   export CF_API_TOKEN="your-api-token"
+#   export CF_ZONE_ID="your-zone-id"
+#   ./scripts/setup-dns.sh
+#
+# To find your Zone ID: Cloudflare Dashboard → your domain → Overview → right sidebar
+# To create an API token: Cloudflare Dashboard → My Profile → API Tokens → Create Token
+#   Required permissions: Zone:DNS:Edit
+#
+
+set -euo pipefail
+
+API_BASE="https://api.cloudflare.com/client/v4"
+DOMAIN="idlefusion.com"
+WORKER_NAME="idlefusion-website"
+
+# ── Validation ──────────────────────────────────────────────────────────────
+
+if [[ -z "${CF_API_TOKEN:-}" ]]; then
+  echo "Error: CF_API_TOKEN is not set."
+  echo "Create one at: https://dash.cloudflare.com/profile/api-tokens"
+  echo "Required permissions: Zone:DNS:Edit"
+  exit 1
+fi
+
+if [[ -z "${CF_ZONE_ID:-}" ]]; then
+  echo "Error: CF_ZONE_ID is not set."
+  echo "Find it at: https://dash.cloudflare.com → your domain → Overview → right sidebar"
+  exit 1
+fi
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+cf_api() {
+  local method="$1"
+  local endpoint="$2"
+  shift 2
+  curl -s -X "$method" \
+    "${API_BASE}${endpoint}" \
+    -H "Authorization: Bearer ${CF_API_TOKEN}" \
+    -H "Content-Type: application/json" \
+    "$@"
+}
+
+get_record_id() {
+  local name="$1"
+  local type="$2"
+  local response
+  response=$(cf_api GET "/zones/${CF_ZONE_ID}/dns_records?type=${type}&name=${name}")
+  echo "$response" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+records = data.get('result', [])
+print(records[0]['id'] if records else '')
+" 2>/dev/null || echo ""
+}
+
+upsert_record() {
+  local name="$1"
+  local type="$2"
+  local content="$3"
+  local proxied="${4:-true}"
+
+  echo "→ ${type} record: ${name} → ${content} (proxied: ${proxied})"
+
+  local record_id
+  record_id=$(get_record_id "$name" "$type")
+
+  local payload
+  payload=$(python3 -c "
+import json
+print(json.dumps({
+    'type': '${type}',
+    'name': '${name}',
+    'content': '${content}',
+    'proxied': ${proxied},
+    'ttl': 1
+}))
+")
+
+  local response
+  if [[ -n "$record_id" ]]; then
+    echo "  Updating existing record (${record_id})..."
+    response=$(cf_api PUT "/zones/${CF_ZONE_ID}/dns_records/${record_id}" -d "$payload")
+  else
+    echo "  Creating new record..."
+    response=$(cf_api POST "/zones/${CF_ZONE_ID}/dns_records" -d "$payload")
+  fi
+
+  local success
+  success=$(echo "$response" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+print('true' if data.get('success') else 'false')
+" 2>/dev/null || echo "false")
+
+  if [[ "$success" == "true" ]]; then
+    echo "  Done."
+  else
+    echo "  Failed:"
+    echo "$response" | python3 -m json.tool 2>/dev/null || echo "$response"
+    return 1
+  fi
+}
+
+# ── DNS Records ─────────────────────────────────────────────────────────────
+
+echo "Setting up DNS records for ${DOMAIN}..."
+echo ""
+
+# Apex domain — CNAME flattened by Cloudflare at the edge
+upsert_record "${DOMAIN}" "CNAME" "${WORKER_NAME}.workers.dev"
+
+# www redirect — CNAME to the same worker, handle redirect in _redirects or worker
+upsert_record "www.${DOMAIN}" "CNAME" "${WORKER_NAME}.workers.dev"
+
+echo ""
+echo "DNS records configured. Verify at:"
+echo "  https://dash.cloudflare.com → ${DOMAIN} → DNS → Records"
+echo ""
+echo "Next steps:"
+echo "  1. npm run deploy    # Deploy your site to Cloudflare Workers"
+echo "  2. Verify https://${DOMAIN} resolves correctly"

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,19 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "idlefusion-website",
+  "compatibility_date": "2025-01-01",
+  "assets": {
+    "directory": "./dist",
+    "not_found_handling": "single-page-application"
+  },
+  "routes": [
+    {
+      "pattern": "idlefusion.com",
+      "custom_domain": true
+    },
+    {
+      "pattern": "www.idlefusion.com",
+      "custom_domain": true
+    }
+  ]
+}


### PR DESCRIPTION
Replace GitHub Pages hosting with Cloudflare Workers static asset
deployment. Adds wrangler.jsonc, a GitHub Actions workflow for CI/CD,
a DNS setup script using the Cloudflare API, and npm scripts for
deploy and dns:setup. Removes the GitHub Pages CNAME file.

https://claude.ai/code/session_01Q3Go8q2VJwADGWPk8jWZyH